### PR TITLE
Major Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v3.0.0 (February 2020)
+* Update to Terraform version 12 syntax
+* Add `custom_header` to both `dynamic_custom_origin_config` and `dynamic_s3_origin_config`
+* Update the way origin group members are assigned.  Fixes [Issue #1](https://github.com/jmgreg31/terraform-aws-cloudfront/issues/1)
+* Remove the dependancy to always have `origin_path` defined
+* Add `lambda_function_assocation` to all cache behaviors.  Fixes [Issue #3](https://github.com/jmgreg31/terraform-aws-cloudfront/issues/3)
+
 ## v2.0.0 (June 2019)
 * Update to `dynamic_custom_origin_config` variable to include `origin_path`
 * Breaking change as you will now need to include this in your variable block

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Latest Release](https://img.shields.io/badge/release-v2.0.0-blue.svg)](https://github.com/jmgreg31/terraform-aws-cloudfront/releases/tag/v2.0.0)
+[![Latest Release](https://img.shields.io/badge/release-v3.0.0-blue.svg)](https://github.com/jmgreg31/terraform-aws-cloudfront/releases/tag/v3.0.0)
 
 # Terraform Cloudfront Module
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -126,24 +126,24 @@ terraform {
 }
 
 module spyderco_cf {
-  source                         = "git::https://github.com/jmgreg31/terraform_aws_cloudfront.git?ref=v1.0.0"
-  alias                          = "${var.alias}"
-  comment                        = "${var.comment}"
-  dynamic_custom_error_response  = "${var.dynamic_custom_error_response}"
-  dynamic_default_cache_behavior = "${var.dynamic_default_cache_behavior}"
-  enable                         = "${var.enable}"
-  enable_ipv6                    = "${var.enable_ipv6}"
-  http_version                   = "${var.http_version}"
-  minimum_protocol_version       = "${var.minimum_protocol_version}"
-  dynamic_ordered_cache_behavior = "${var.dynamic_ordered_cache_behavior}"
-  dynamic_custom_origin_config   = "${var.dynamic_custom_origin_config}"
-  dynamic_s3_origin_config       = "${var.dynamic_s3_origin_config}"
-  dynamic_origin_group           = "${var.dynamic_origin_group}"
-  price                          = "${var.price}"
-  region                         = "${var.region}"
-  restriction_type               = "${var.restriction_type}"
-  ssl_certificate                = "${var.ssl_certificate}"
-  ssl_support_method             = "${var.ssl_support_method}"
-  tag_name                       = "${var.tag_name}"
-  webacl                         = "${var.webacl}"
+  source                         = "git::https://github.com/jmgreg31/terraform_aws_cloudfront.git?ref=v3.0.0"
+  alias                          = var.alias
+  comment                        = var.comment
+  dynamic_custom_error_response  = var.dynamic_custom_error_response
+  dynamic_default_cache_behavior = var.dynamic_default_cache_behavior
+  enable                         = var.enable
+  enable_ipv6                    = var.enable_ipv6
+  http_version                   = var.http_version
+  minimum_protocol_version       = var.minimum_protocol_version
+  dynamic_ordered_cache_behavior = var.dynamic_ordered_cache_behavior
+  dynamic_custom_origin_config   = var.dynamic_custom_origin_config
+  dynamic_s3_origin_config       = var.dynamic_s3_origin_config
+  dynamic_origin_group           = var.dynamic_origin_group
+  price                          = var.price
+  region                         = var.region
+  restriction_type               = var.restriction_type
+  ssl_certificate                = var.ssl_certificate
+  ssl_support_method             = var.ssl_support_method
+  tag_name                       = var.tag_name
+  webacl                         = var.webacl
 }

--- a/example/terraform.tfvars
+++ b/example/terraform.tfvars
@@ -18,7 +18,6 @@ dynamic_s3_origin_config = [
     domain_name            = "domain.s3.amazonaws.com"
     origin_id              = "S3-domain-cert"
     origin_access_identity = "origin-access-identity/cloudfront/1234"
-    origin_path            = ""
   },
   {
     domain_name            = "domain2.s3.amazonaws.com"
@@ -32,13 +31,22 @@ dynamic_custom_origin_config = [
   {
     domain_name              = "mydomain.google.com"
     origin_id                = "mydomainorigin.google.com"
-    origin_path              = ""
     http_port                = 80
     https_port               = 443
     origin_keepalive_timeout = 5
     origin_read_timeout      = 30
     origin_protocol_policy   = "https-only"
     origin_ssl_protocols     = ["TLSv1.2", "TLSv1.1"]
+    custom_header            = [
+      {
+        name                 = "Test"
+        value                = "Test-Header"
+      },
+      {
+        name                 = "Test2"
+        value                = "Test2-Header"
+      }
+    ]
   },
   {
     domain_name              = "mydomain2.google.com"
@@ -57,33 +65,37 @@ dynamic_origin_group = [
   {
     origin_id    = "OriginGroup-1-S3-cert"
     status_codes = [403, 404, 500, 502, 503, 504]
-    member1      = "S3-cert-east"
-    member2      = "S3-cert-west"
+    member1      = [
+      {
+        origin_id = "S3-cert-east"
+      },
+      {
+        origin_id = "S3-cert-west"
+      }
+    ]
   }
 ]
 
-// origin_group_member = [
-//   {
-//     origin_id = "S3-mobileedge-ease-qa-cert"
-//   },
-//   {
-//     origin_id = "S3-mobileedge-ease-qa-west"
-//   }
-// ]
-
 dynamic_default_cache_behavior = [
   {
-    allowed_methods        = ["GET", "HEAD", "OPTIONS", "POST", "PUT", "DELETE", "PATCH"]
-    cached_methods         = ["GET", "HEAD"]
-    target_origin_id       = "mydomainorigin.google.com"
-    compress               = false
-    query_string           = true
-    cookies_forward        = "all"
-    headers                = ["*"]
-    viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
-    default_ttl            = 0
-    max_ttl                = 0
+    allowed_methods             = ["GET", "HEAD", "OPTIONS", "POST", "PUT", "DELETE", "PATCH"]
+    cached_methods              = ["GET", "HEAD"]
+    target_origin_id            = "mydomainorigin.google.com"
+    compress                    = false
+    query_string                = true
+    cookies_forward             = "all"
+    headers                     = ["*"]
+    viewer_protocol_policy      = "redirect-to-https"
+    min_ttl                     = 0
+    default_ttl                 = 0
+    max_ttl                     = 0
+    lambda_function_association = [
+      {
+        event_type = "viewer-request"
+        lambda_arn = "YOUR LAMBDA ARN"
+        include_body = true
+      }
+    ]
   }
 ]
 

--- a/main.tf
+++ b/main.tf
@@ -1,27 +1,38 @@
 resource "aws_cloudfront_distribution" "cloudfront_distribution" {
-  aliases             = "${var.alias}"
-  comment             = "${var.comment}"
-  default_root_object = "${var.default_root_object}"
-  enabled             = "${var.enable}"
-  http_version        = "${var.http_version}"
-  is_ipv6_enabled     = "${var.enable_ipv6}"
-  price_class         = "${var.price}"
-  retain_on_delete    = "${var.retain_on_delete}"
-  wait_for_deployment = "${var.wait_for_deployment}"
-  web_acl_id          = "${var.webacl}"
-  
+  aliases             = var.alias
+  comment             = var.comment
+  default_root_object = var.default_root_object
+  enabled             = var.enable
+  http_version        = var.http_version
+  is_ipv6_enabled     = var.enable_ipv6
+  price_class         = var.price
+  retain_on_delete    = var.retain_on_delete
+  wait_for_deployment = var.wait_for_deployment
+  web_acl_id          = var.webacl
+
   dynamic "origin" {
-    for_each = [for i in "${var.dynamic_s3_origin_config}" : {
-      name     = i.domain_name
-      id       = i.origin_id
-      identity = i.origin_access_identity
-      path     = i.origin_path
+    for_each = [for i in var.dynamic_s3_origin_config : {
+      name          = i.domain_name
+      id            = i.origin_id
+      identity      = i.origin_access_identity
+      path          = lookup(i, "origin_path", null)
+      custom_header = lookup(i, "custom_header", null)
     }]
 
     content {
       domain_name = origin.value.name
       origin_id   = origin.value.id
       origin_path = origin.value.path
+      dynamic "custom_header" {
+        for_each = origin.value.custom_header == null ? [] : [for i in origin.value.custom_header : {
+          name  = i.name
+          value = i.value
+        }]
+        content {
+          name  = custom_header.value.name
+          value = custom_header.value.value
+        }
+      }
       s3_origin_config {
         origin_access_identity = origin.value.identity
       }
@@ -29,21 +40,32 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   }
 
   dynamic "origin" {
-    for_each = [for i in "${var.dynamic_custom_origin_config}" : {
+    for_each = [for i in var.dynamic_custom_origin_config : {
       name                     = i.domain_name
       id                       = i.origin_id
-      path                     = i.origin_path
+      path                     = lookup(i, "origin_path", null)
       http_port                = i.http_port
       https_port               = i.https_port
       origin_keepalive_timeout = i.origin_keepalive_timeout
       origin_read_timeout      = i.origin_read_timeout
       origin_protocol_policy   = i.origin_protocol_policy
       origin_ssl_protocols     = i.origin_ssl_protocols
+      custom_header            = lookup(i, "custom_header", null)
     }]
     content {
       domain_name = origin.value.name
       origin_id   = origin.value.id
       origin_path = origin.value.path
+      dynamic "custom_header" {
+        for_each = origin.value.custom_header == null ? [] : [for i in origin.value.custom_header : {
+          name  = i.name
+          value = i.value
+        }]
+        content {
+          name  = custom_header.value.name
+          value = custom_header.value.value
+        }
+      }
       custom_origin_config {
         http_port                = origin.value.http_port
         https_port               = origin.value.https_port
@@ -56,49 +78,41 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   }
 
   dynamic "origin_group" {
-    for_each = [for i in "${var.dynamic_origin_group}" : {
+    for_each = [for i in var.dynamic_origin_group : {
       id           = i.origin_id
       status_codes = i.status_codes
-      member1      = i.member1
-      member2      = i.member2
+      member1      = lookup(i, "member", null)
     }]
-
     content {
       origin_id = origin_group.value.id
       failover_criteria {
         status_codes = origin_group.value.status_codes
       }
-      // dynamic "member" {
-      //   for_each = [for j in "${var.origin_group_member}": {
-      //     id = j.origin_id
-      //   }]
-
-      //     content {
-      //       origin_id = member.value.id
-      //     }
-      // }
-      member {
-        origin_id = origin_group.value.member1
-      }
-      member {
-        origin_id = origin_group.value.member2
+      dynamic "member" {
+        for_each = origin_group.value.member == null ? [] : [for i in origin_group.value.member : {
+          id = i.origin_id
+        }]
+        content {
+          origin_id = member.value.id
+        }
       }
     }
   }
 
   dynamic "default_cache_behavior" {
-    for_each = [for i in "${var.dynamic_default_cache_behavior}" : {
-      allowed_methods        = i.allowed_methods
-      cached_methods         = i.cached_methods
-      target_origin_id       = i.target_origin_id
-      compress               = i.compress
-      query_string           = i.query_string
-      cookies_forward        = i.cookies_forward
-      headers                = i.headers
-      viewer_protocol_policy = i.viewer_protocol_policy
-      min_ttl                = i.min_ttl
-      default_ttl            = i.default_ttl
-      max_ttl                = i.max_ttl
+    for_each = [for i in var.dynamic_default_cache_behavior : {
+      allowed_methods             = i.allowed_methods
+      cached_methods              = i.cached_methods
+      target_origin_id            = i.target_origin_id
+      compress                    = i.compress
+      query_string                = i.query_string
+      cookies_forward             = i.cookies_forward
+      headers                     = i.headers
+      viewer_protocol_policy      = i.viewer_protocol_policy
+      min_ttl                     = i.min_ttl
+      default_ttl                 = i.default_ttl
+      max_ttl                     = i.max_ttl
+      lambda_function_association = lookup(i, "lambda_function_association", null)
     }]
     content {
       allowed_methods  = default_cache_behavior.value.allowed_methods
@@ -113,6 +127,20 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
         }
         headers = default_cache_behavior.value.headers
       }
+
+      dynamic "lambda_function_association" {
+        for_each = default_cache_behavior.value.lambda_function_association == null ? [] : [for i in default_cache_behavior.value.lambda_function_association : {
+          event_type   = i.event_type
+          lambda_arn   = i.lambda_arn
+          include_body = i.include_body
+        }]
+        content {
+          event_type   = lambda_function_association.value.event_type
+          lambda_arn   = lambda_function_association.value.lambda_arn
+          include_body = lambda_function_association.value.include_body
+        }
+      }
+
       viewer_protocol_policy = default_cache_behavior.value.viewer_protocol_policy
       min_ttl                = default_cache_behavior.value.min_ttl
       default_ttl            = default_cache_behavior.value.default_ttl
@@ -121,19 +149,20 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   }
 
   dynamic "ordered_cache_behavior" {
-    for_each = [for i in "${var.dynamic_ordered_cache_behavior}" : {
-      path_pattern           = i.path_pattern
-      allowed_methods        = i.allowed_methods
-      cached_methods         = i.cached_methods
-      target_origin_id       = i.target_origin_id
-      compress               = i.compress
-      query_string           = i.query_string
-      cookies_forward        = i.cookies_forward
-      headers                = i.headers
-      viewer_protocol_policy = i.viewer_protocol_policy
-      min_ttl                = i.min_ttl
-      default_ttl            = i.default_ttl
-      max_ttl                = i.max_ttl
+    for_each = [for i in var.dynamic_ordered_cache_behavior : {
+      path_pattern                = i.path_pattern
+      allowed_methods             = i.allowed_methods
+      cached_methods              = i.cached_methods
+      target_origin_id            = i.target_origin_id
+      compress                    = i.compress
+      query_string                = i.query_string
+      cookies_forward             = i.cookies_forward
+      headers                     = i.headers
+      viewer_protocol_policy      = i.viewer_protocol_policy
+      min_ttl                     = i.min_ttl
+      default_ttl                 = i.default_ttl
+      max_ttl                     = i.max_ttl
+      lambda_function_association = lookup(i, "lambda_function_association", null)
     }]
     content {
       path_pattern     = ordered_cache_behavior.value.path_pattern
@@ -149,6 +178,20 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
         }
         headers = ordered_cache_behavior.value.headers
       }
+
+      dynamic "lambda_function_association" {
+        for_each = ordered_cache_behavior.value.lambda_function_association == null ? [] : [for i in ordered_cache_behavior.value.lambda_function_association : {
+          event_type   = i.event_type
+          lambda_arn   = i.lambda_arn
+          include_body = i.include_body
+        }]
+        content {
+          event_type   = lambda_function_association.value.event_type
+          lambda_arn   = lambda_function_association.value.lambda_arn
+          include_body = lambda_function_association.value.include_body
+        }
+      }
+
       viewer_protocol_policy = ordered_cache_behavior.value.viewer_protocol_policy
       min_ttl                = ordered_cache_behavior.value.min_ttl
       default_ttl            = ordered_cache_behavior.value.default_ttl
@@ -157,7 +200,7 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   }
 
   dynamic "custom_error_response" {
-    for_each = [for i in "${var.dynamic_custom_error_response}" : {
+    for_each = [for i in var.dynamic_custom_error_response : {
       error_caching_min_ttl = i.error_caching_min_ttl
       error_code            = i.error_code
       response_code         = i.response_code
@@ -173,7 +216,7 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   }
 
   dynamic "logging_config" {
-    for_each = [for i in "${var.dynamic_logging_config}" : {
+    for_each = [for i in var.dynamic_logging_config : {
       bucket          = i.bucket
       include_cookies = i.include_cookies
       prefix          = i.prefix
@@ -187,19 +230,19 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   }
 
   tags = {
-    Name            = "${var.tag_name}"
+    Name = var.tag_name
   }
 
   restrictions {
     geo_restriction {
-      locations        = "${var.restriction_location}"
-      restriction_type = "${var.restriction_type}"
+      locations        = var.restriction_location
+      restriction_type = var.restriction_type
     }
   }
 
   viewer_certificate {
-    iam_certificate_id       = "${var.ssl_certificate}"
-    minimum_protocol_version = "${var.minimum_protocol_version}"
-    ssl_support_method       = "${var.ssl_support_method}"
+    iam_certificate_id       = var.ssl_certificate
+    minimum_protocol_version = var.minimum_protocol_version
+    ssl_support_method       = var.ssl_support_method
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "name" {
-  value       = "${aws_cloudfront_distribution.cloudfront_distribution.domain_name}"
+  value       = aws_cloudfront_distribution.cloudfront_distribution.domain_name
   description = "The domain name of the CloudFront distribution"
 }

--- a/provider.tf
+++ b/provider.tf
@@ -1,4 +1,4 @@
 provider "aws" {
   version = "~> 2.14"
-  region  = "${var.region}"
+  region  = var.region
 }


### PR DESCRIPTION
* Update to Terraform version 12 syntax
* Add `custom_header` to both `dynamic_custom_origin_config` and `dynamic_s3_origin_config`
* Update the way origin group members are assigned.  Fixes [Issue #1](https://github.com/jmgreg31/terraform-aws-cloudfront/issues/1)
* Remove the dependancy to always have `origin_path` defined
* Add `lambda_function_assocation` to all cache behaviors.  Fixes [Issue #3](https://github.com/jmgreg31/terraform-aws-cloudfront/issues/3)
