### PR TITLE
Allow configuring custom headers in S3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED (October 2020)
+
+* fix `dynamic_s3_origin_config` variable, to match the configuration of `dynamic_custom_origin_config`. This fixes a bug where `custom_headers` couldn't be set.
+
 ## v4.3.1 (September 2020)
 
 * refactored the `dynamic_custom_error_response` variable, specifying all the fields is not needed anymore

--- a/example/terraform.tfvars
+++ b/example/terraform.tfvars
@@ -27,6 +27,16 @@ dynamic_s3_origin_config = [
     origin_id              = "S3-domain2-cert"
     origin_access_identity = "origin-access-identity/cloudfront/1234"
     origin_path            = ""
+    custom_header = [
+      {
+        name  = "Test"
+        value = "Test-Header"
+      },
+      {
+        name  = "Test2"
+        value = "Test2-Header"
+      }
+    ]
   }
 ]
 

--- a/variables.tf
+++ b/variables.tf
@@ -89,7 +89,7 @@ variable dynamic_logging_config {
 
 variable dynamic_s3_origin_config {
   description = "Configuration for the s3 origin config to be used in dynamic block"
-  type        = list(map(string))
+  type        = any
   default     = []
 }
 
@@ -119,11 +119,11 @@ variable iam_certificate_id {
 
 variable minimum_protocol_version {
   description = <<EOF
-    The minimum version of the SSL protocol that you want CloudFront to use for HTTPS connections. 
-    One of SSLv3, TLSv1, TLSv1_2016, TLSv1.1_2016,TLSv1.2_2018 or TLSv1.2_2019. Default: TLSv1. 
-    NOTE: If you are using a custom certificate (specified with acm_certificate_arn or iam_certificate_id), 
-    and have specified sni-only in ssl_support_method, TLSv1 or later must be specified. 
-    If you have specified vip in ssl_support_method, only SSLv3 or TLSv1 can be specified. 
+    The minimum version of the SSL protocol that you want CloudFront to use for HTTPS connections.
+    One of SSLv3, TLSv1, TLSv1_2016, TLSv1.1_2016,TLSv1.2_2018 or TLSv1.2_2019. Default: TLSv1.
+    NOTE: If you are using a custom certificate (specified with acm_certificate_arn or iam_certificate_id),
+    and have specified sni-only in ssl_support_method, TLSv1 or later must be specified.
+    If you have specified vip in ssl_support_method, only SSLv3 or TLSv1 can be specified.
     If you have specified cloudfront_default_certificate, TLSv1 must be specified.
     EOF
 


### PR DESCRIPTION
Mimicking the functionality and implementation of `dynamic_custom_origin_config` variable.
Currently this is not possible due to variable validations and will result in a validation failure.


IDE auto removed redundant white spaces.